### PR TITLE
feat: SeablastTranslate::translate() becomes multi-lingual

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   # Note: https://docs.github.com/en/actions/using-workflows/reusing-workflows The strategy property is not supported in any job that calls a reusable workflow.
   php-composer-unit-stan:
-    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.5.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/php-composer-dependencies-reusable.yml@v0.2.6
     with:
       # JSON
       php-version: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Invoke the PHPCS check and PHPCBF fix
-        uses: WorkOfStan/phpcs-fix@v1.0.2
+        uses: WorkOfStan/phpcs-fix@v1.0.3
         with:
           commit-changes: ${{ github.event_name != 'schedule' }}
           php-version: "7.4"
@@ -65,6 +65,6 @@ jobs:
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@dependabot/github_actions/super-linter/super-linter-8.2.0
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.6
     with:
       runs-on: "ubuntu-latest"

--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Invoke the Prettier fix
         uses: WorkOfStan/prettier-fix@v1.1.6.1
         with:
-          commit-changes: true
+          commit-changes: ${{ github.event_name != 'schedule' }}
 
   phpcs-phpcbf:
     needs: prettier-fix
@@ -59,12 +59,12 @@ jobs:
       - name: Invoke the PHPCS check and PHPCBF fix
         uses: WorkOfStan/phpcs-fix@v1.0.2
         with:
-          commit-changes: true
+          commit-changes: ${{ github.event_name != 'schedule' }}
           php-version: "7.4"
           stop-on-manual-fix: true
 
   super-linter:
     needs: phpcs-phpcbf
-    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@v0.2.5.2
+    uses: WorkOfStan/seablast-actions/.github/workflows/linter.yml@dependabot/github_actions/super-linter/super-linter-8.2.0
     with:
       runs-on: "ubuntu-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.1] - 2025-10-04
 
-- feat: SeablastTranslate::translate() becomes multi-lingual
+feat: SeablastTranslate::translate() becomes multi-lingual
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Changed` for changes in existing functionality
 
-- chore: bumped the versions of GitHub Actions and blast.sh
-
 ### `Deprecated` for soon-to-be removed features
 
 ### `Removed` for now removed features
@@ -20,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Fixed` for any bugfixes
 
 ### `Security` in case of vulnerabilities
+
+## [0.1.1] - 2025-10-04
+
+- feat: SeablastTranslate::translate() becomes multi-lingual
+
+### Added
+
+- feat: SeablastTranslate::translate($original, OPTIONAL $language) in order to be able to translate for multiple user, e.g. in case of emailing
+
+### Changed
+
+- chore: bumped the versions of GitHub Actions and blast.sh
 
 ## [0.1] - 2025-08-03
 
@@ -33,5 +43,6 @@ feat: library to handle language switching and localisation of selected strings
 - package limited to the tested PHP versions, i.e. "php": ">=7.2 <8.5"
 - API `'/api/language'` using `'model' => '\Seablast\I18n\Models\ApiLanguageModel'` returns the selected language or it receives language to be set in the cookie 'sbLanguage'.
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1...v0.1.1
 [0.1]: https://github.com/WorkOfStan/seablast-i18n/releases/tag/v0.1

--- a/src/Models/ApiLanguageModel.php
+++ b/src/Models/ApiLanguageModel.php
@@ -26,7 +26,7 @@ class ApiLanguageModel extends GenericRestApiJsonModel
      */
     public function __construct(SeablastConfiguration $configuration, Superglobals $superglobals)
     {
-        // todo tato metoda opakuje parent::construct pro případ GET? refactor somehow?
+        // todo this method repeats parent::construct in case of a GET call? refactor somehow?
         $this->configuration = $configuration;
         // Read JSON from standard input if not pre-prepared
         $jsonInput = $this->configuration->exists(SeablastConstant::JSON_INPUT) //
@@ -76,6 +76,12 @@ class ApiLanguageModel extends GenericRestApiJsonModel
             ? self::response(200, 'Language set.') : self::response(500, 'Language failed');
     }
 
+    /**
+     * Checks existence of a cookie `sbLanguage` and validates it; or returns the default language.
+     *
+     * @return string
+     * @throws \Exception
+     */
     private function getLanguageValue(): string
     {
         // Check if the cookie exists and is not empty
@@ -110,7 +116,7 @@ class ApiLanguageModel extends GenericRestApiJsonModel
                 $this->data->language,
                 time() + 30 * 24 * 60 * 60, // expire time: days * hours * minutes * seconds
                 $this->configuration->getString(SeablastConstant::SB_SESSION_SET_COOKIE_PARAMS_PATH),
-                '', // default cookie host
+                '', // the default cookie host
                 true,
                 true
             );

--- a/src/Models/FetchLocalisedItemsModel.php
+++ b/src/Models/FetchLocalisedItemsModel.php
@@ -109,7 +109,7 @@ class FetchLocalisedItemsModel implements SeablastModelInterface
                     item_type_id, active, created_at, updated_at
                 FROM `{$this->configuration->dbmsTablePrefix()}localised_items`
                 WHERE language = ? AND item_type_id = ? AND active = 1
-                ORDER BY created_at DESC
+                ORDER BY created_at DESC;
             ";
             $stmt = $this->configuration->mysqli()->prepareStrict($sql);
             $stmt->bind_param('si', $language, $itemTypeId);
@@ -120,7 +120,7 @@ class FetchLocalisedItemsModel implements SeablastModelInterface
                     id, item_id, language, parent_id, title, content,
                     friendly_url, item_type_id, active, created_at, updated_at
                 FROM `{$this->configuration->dbmsTablePrefix()}localised_items`
-                WHERE item_id = ? AND language = ? AND item_type_id = ? AND active = 1
+                WHERE item_id = ? AND language = ? AND item_type_id = ? AND active = 1;
             ";
             $stmt = $this->configuration->mysqli()->prepareStrict($sql);
             $stmt->bind_param('isi', $itemId, $language, $itemTypeId);

--- a/src/SeablastTranslate.php
+++ b/src/SeablastTranslate.php
@@ -17,7 +17,7 @@ class SeablastTranslate
 
     /** @var SeablastConfiguration */
     private $configuration;
-    /** @var array<string> */
+    /** @var array<array<string>> */
     private $translations = [];
 
     /**
@@ -65,16 +65,24 @@ class SeablastTranslate
 
     /**
      * Populates $this->translations dictionary.
+     *
+     * @param string|null $language [OPTIONAL] If null, the current user's language is used.
+     * @return void
+     * @throws DbmsException
      */
-    private function retrieveTranslations(): void
+    private function retrieveTranslations(?string $language = null): void
     {
+        // validity of $language against `I18nConstant::LANGUAGE_LIST` was already checked
+        if (is_null($language)) {
+            $language = $this->getLanguage();
+        }
         //Debugger::barDump('retrieveTranslations called');
         // get translations from db to array according to the SB:LANGUAGE
         $stmt = $this->configuration->mysqli()->prepareStrict(
             'SELECT translation_key, translation_value FROM `' . $this->configuration->dbmsTablePrefix() //
             . 'translations` WHERE language = ?'
         );
-        $stmt->bind_param('s', $this->getLanguage());
+        $stmt->bind_param('s', $language);          
         $stmt->execute();
         $result = $stmt->get_result();
         if ($result === false) {
@@ -83,19 +91,34 @@ class SeablastTranslate
         }
 
         while ($row = $result->fetch_assoc()) {
-            $this->translations[$row['translation_key']] = (string) $row['translation_value'];
+            $this->translations[$language][$row['translation_key']] = (string) $row['translation_value'];
         }
 
         $stmt->close();
     }
 
-    public function translate(string $original): string
+    /**
+     * Returns the dictionary translation of a string.
+     *
+     * @param string $original
+     * @param string|null $language [OPTIONAL] If null, the current user's language is used.
+     * @return string
+     */
+    public function translate(string $original, ?string $language = null): string
     {
+        if(is_null($language)) {
+            $language = $this->getLanguage();
+        } else {
+            if(!in_array($language, $this->configuration->getArrayString(I18nConstant::LANGUAGE_LIST))) {
+                throw new \Exception("`{$language}` is not among expected languages");
+            }
+        }
+        
         // Lazy init
-        if (empty($this->translations)) {
-            $this->retrieveTranslations();
+        if (empty($this->translations) || empty($this->translations[$language])) {
+            $this->retrieveTranslations($language);
         }
         // $original => translated according to getString(SB:LANGUAGE)
-        return $this->translations[$original] ?? $original;
+        return $this->translations[$language][$original] ?? $original;
     }
 }

--- a/src/SeablastTranslate.php
+++ b/src/SeablastTranslate.php
@@ -82,7 +82,7 @@ class SeablastTranslate
             'SELECT translation_key, translation_value FROM `' . $this->configuration->dbmsTablePrefix() //
             . 'translations` WHERE language = ?'
         );
-        $stmt->bind_param('s', $language);          
+        $stmt->bind_param('s', $language);
         $stmt->execute();
         $result = $stmt->get_result();
         if ($result === false) {
@@ -106,14 +106,14 @@ class SeablastTranslate
      */
     public function translate(string $original, ?string $language = null): string
     {
-        if(is_null($language)) {
+        if (is_null($language)) {
             $language = $this->getLanguage();
         } else {
-            if(!in_array($language, $this->configuration->getArrayString(I18nConstant::LANGUAGE_LIST))) {
+            if (!in_array($language, $this->configuration->getArrayString(I18nConstant::LANGUAGE_LIST))) {
                 throw new \Exception("`{$language}` is not among expected languages");
             }
         }
-        
+
         // Lazy init
         if (empty($this->translations) || empty($this->translations[$language])) {
             $this->retrieveTranslations($language);


### PR DESCRIPTION
### Added

- feat: SeablastTranslate::translate($original, OPTIONAL $language) in order to be able to translate for multiple user, e.g. in case of emailing

### Changed

- chore: bumped the versions of GitHub Actions and blast.sh