### PR TITLE
feat: control rendering of `uls.*.latte` via the `I18n:SHOW_LANGUAGE_SELECTOR` flag

### DIFF
--- a/.github/workflows/polish-the-code.yml
+++ b/.github/workflows/polish-the-code.yml
@@ -28,7 +28,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write # so that it can actually write pr-comments
+      # so that it can actually write pr-comments
+      issues: write
     # Limit the running time
     timeout-minutes: 10
     steps:
@@ -87,7 +88,7 @@ jobs:
         uses: WorkOfStan/phpcs-fix@v1
         with:
           commit-changes: ${{ github.event_name != 'schedule' }}
-          php-version: "7.4"
+          php-version: "8.2"
           stop-on-manual-fix: true
 
   super-linter:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Security` in case of vulnerabilities
 
+## [0.1.3] - 2026-01-25
+
+feat: control rendering of `uls.*.latte` via the `I18n:SHOW_LANGUAGE_SELECTOR` flag
+
+### Changed
+
+- The `I18n:SHOW_LANGUAGE_SELECTOR` flag now controls whether the contents of all `uls.*.latte` templates are rendered. You no longer need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
+
 ## [0.1.2] - 2025-12-27
 
 feat: add PHP/8.5 support
@@ -56,7 +64,8 @@ feat: library to handle language switching and localisation of selected strings
 - package limited to the tested PHP versions, i.e. "php": ">=7.2 <8.5"
 - API `'/api/language'` using `'model' => '\Seablast\I18n\Models\ApiLanguageModel'` returns the selected language or it receives language to be set in the cookie 'sbLanguage'.
 
-[Unreleased]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/WorkOfStan/seablast-i18n/compare/v0.1...v0.1.1
 [0.1]: https://github.com/WorkOfStan/seablast-i18n/releases/tag/v0.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `Seablast\I18n`
+# `Seablast I18n`
 
 A lightweight internationalization (i18n) module designed for apps using the [Seablast for PHP](https://github.com/WorkOfStan/seablast) framework. Installable via Composer, it integrates seamlessly and activates only when needed, allowing you to effortlessly provide multilingual support and manage user language preferences.
 
@@ -44,7 +44,7 @@ To display the language selector, include the three `uls.*.latte` files as follo
 </html>
 ```
 
-Note: The `I18n:SHOW_LANGUAGE_SELECTOR` flag controls whether the contents of all `uls.*.latte` templates are rendered. You don't need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
+Note: The `I18n:SHOW_LANGUAGE_SELECTOR` flag controls whether the contents of all `uls.*.latte` templates are rendered. As a result, you don't need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
 
 Instead of language selector, you can switch the language programatically by calling
 
@@ -108,7 +108,7 @@ To create the expected database table structure (for dictionary and localised it
 ## Integration
 
 - Seablast/Seablast::v0.2.11 contains `APP_DIR . '/vendor/seablast/i18n/conf/app.conf.php', // Seablast/i18n extension configuration` so use at least this Seablast version.
-- `"seablast/seablast": "^0.2.7"` is in the `require-dev` section of `composer.json` because the app that uses Seablast\I18n may use whatever dev version of Seablast.
+- `"seablast/seablast": "^0.2.7"` is in the `require-dev` section of `composer.json` because the app that uses Seablast I18n may use whatever dev version of Seablast.
 
 ### Language API
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ To display the language selector, include the three `uls.*.latte` files as follo
 </html>
 ```
 
+Note:  The `I18n:SHOW_LANGUAGE_SELECTOR` flag controls whether the contents of all `uls.*.latte` templates are rendered. You don't need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
+
 Instead of language selector, you can switch the language programatically by calling
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To display the language selector, include the three `uls.*.latte` files as follo
 </html>
 ```
 
-Note:  The `I18n:SHOW_LANGUAGE_SELECTOR` flag controls whether the contents of all `uls.*.latte` templates are rendered. You don't need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
+Note: The `I18n:SHOW_LANGUAGE_SELECTOR` flag controls whether the contents of all `uls.*.latte` templates are rendered. You don't need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.
 
 Instead of language selector, you can switch the language programatically by calling
 

--- a/views/uls.css.latte
+++ b/views/uls.css.latte
@@ -1,4 +1,5 @@
+{if $configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')}
     <link rel="stylesheet" href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/css/jquery.uls.css?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}">
     <link rel="stylesheet" href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/css/jquery.uls.grid.css?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}">
     <link rel="stylesheet" href="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/css/jquery.uls.lcd.css?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}">
-
+{/if}

--- a/views/uls.js.latte
+++ b/views/uls.js.latte
@@ -1,3 +1,4 @@
+{if $configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')}
     <script src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/src/jquery.uls.data.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script>
     <script src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/src/jquery.uls.data.utils.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script>
     <script src="{$configuration->getString('SB_APP_ROOT_ABSOLUTE_URL')}/vendor/seablast/seablast/assets/uls/src/jquery.uls.lcd.js?v={$configuration->getInt('SB_WEB_FORCE_ASSET_VERSION')}"></script>
@@ -87,3 +88,4 @@ $(document).on('sbI18nLanguageSelectorReady', function () {
   });
 });
     </script>
+{/if}

--- a/views/uls.menu.latte
+++ b/views/uls.menu.latte
@@ -1,1 +1,1 @@
-<a href="#" class="uls-trigger"><span class="icon">{include file '../../seablast/assets/uls/images/language.svg'}</span>{=''|translate}{$configuration->getString('SB:LANGUAGE')|upper}</a>
+<a n:if="$configuration->flag->status('I18n:SHOW_LANGUAGE_SELECTOR')" href="#" class="uls-trigger"><span class="icon">{include file '../../seablast/assets/uls/images/language.svg'}</span>{=''|translate}{$configuration->getString('SB:LANGUAGE')|upper}</a>


### PR DESCRIPTION
### Changed

- The `I18n:SHOW_LANGUAGE_SELECTOR` flag now controls whether the contents of all `uls.*.latte` templates are rendered. You no longer need to wrap `uls.*.latte` includes in custom Latte templates with conditional logic—just include them, and the application will decide (via the `I18n:SHOW_LANGUAGE_SELECTOR` flag) whether they take effect.